### PR TITLE
Change the broken Couchbase Lite link

### DIFF
--- a/_docs/databases/html.html
+++ b/_docs/databases/html.html
@@ -13,7 +13,7 @@
   <a href="http://bigcouch.cloudant.com/">BigCouch</a>) to the Apache Foundation
   and it is intended to be the basis of a future Apache CouchDB.
   </dd>
-  <dt><a href="http://www.couchbase.com/communities/couchbase-lite">Couchbase Lite (TouchDB)</a></dt>
+  <dt><a href="http://developer.couchbase.com/mobile/develop/guides/couchbase-lite/index.html">Couchbase Lite (TouchDB)</a></dt>
   <dd>Couchbase Lite (formerly TouchDB) is a lightweight Apache
     CouchDB-compatible database engine suitable for embedding into
     mobile or desktop apps. There are both iOS and Android vairants.


### PR DESCRIPTION
The link to Couchbase Lite is broken, they've seem to have rebranded it slightly: http://www.couchbase.com/mobile

Alternatively we could link to http://developer.couchbase.com/mobile/develop/guides/couchbase-lite/index.html
