### PR TITLE
Add the replication web service for Drupal as an early stage replicating endpoint

### DIFF
--- a/_docs/databases/html.html
+++ b/_docs/databases/html.html
@@ -32,5 +32,6 @@
     <dt><a href="https://github.com/jo/roy-replicator">roy-replicator</a></dt>
     <dt><a href="https://github.com/kxepal/replipy">replipy</a> (a testing implementation)</dt>
     <dt><a href="https://github.com/mikeal/replicate">replicate</a></dt>
+    <dt><a href="https://www.drupal.org/project/replication">Replication Web Service for Drupal</a></dt>
   </dd>
 </dl>


### PR DESCRIPTION
I'm leading an effort to implement the CouchDB replication protocol for Drupal, to be used for various things like offline apps, content staging and replication etc. It would be nice to add a note about that on the replication.io website.
